### PR TITLE
Add maxval argument when using progressbar as a function.

### DIFF
--- a/examples.py
+++ b/examples.py
@@ -338,6 +338,15 @@ def example27():
     pbar.update(1)
     pbar.finish()
 
+@example
+def example28():
+    # Testing using progressbar as an iterator with a max value
+    pbar = ProgressBar()
+
+    for n in pbar(iter(range(100)), 100):
+        # iter range is a way to get an iterator in both python 2 and 3
+        pass
+
 if __name__ == '__main__':
     try:
         for example in examples:

--- a/progressbar/__init__.py
+++ b/progressbar/__init__.py
@@ -169,14 +169,16 @@ class ProgressBar(object):
         self.start_time = None
         self.update_interval = 1
 
-    def __call__(self, iterable):
+    def __call__(self, iterable, maxval=None):
         'Use a ProgressBar to iterate through an iterable'
-
-        try:
-            self.maxval = len(iterable)
-        except:
-            if self.maxval is None:
-                self.maxval = UnknownLength
+        if maxval is None:
+            try:
+                self.maxval = len(iterable)
+            except:
+                if self.maxval is None:
+                    self.maxval = UnknownLength
+        else:
+            self.maxval = maxval
 
         self.__iterable = iter(iterable)
         return self


### PR DESCRIPTION
Hi! First of all, thanks for putting up an up-to-date version of progressbar on pypi since the original one is a bit borked right now.

Secondly, I often use progressbar with iterators for which I already know the length beforehand, but don't work with len(), like queries from databases, so it would be a lot handier for me if I could set the length as a positional argument when using a ProgressBar as an iterator. I know I can just set it when instantiating the ProgressBar, but I always forget the key-arg's name.
