### PR TITLE
Added correct exception type to ProgressBar.__call__

### DIFF
--- a/progressbar/bar.py
+++ b/progressbar/bar.py
@@ -347,7 +347,7 @@ class ProgressBar(StdRedirectMixin, ResizableMixin, ProgressBarBase):
         if max_value is None:
             try:
                 self.max_value = len(iterable)
-            except:
+            except TypeError:
                 if self.max_value is None:
                     self.max_value = UnknownLength
         else:


### PR DESCRIPTION
NEVER NEVER NEVER use an `except` without a type without reraising it.