### PR TITLE
Timing format improvements

### DIFF
--- a/progressbar/bar.py
+++ b/progressbar/bar.py
@@ -306,7 +306,8 @@ class ProgressBar(StdRedirectMixin, ResizableMixin, ProgressBarBase):
             # The seconds since the bar started
             total_seconds_elapsed=total_seconds_elapsed,
             # The seconds since the bar started modulo 60
-            seconds_elapsed=(elapsed.seconds % 60) + elapsed.microseconds,
+            seconds_elapsed=(elapsed.seconds % 60) +
+            (elapsed.microseconds / 1000000.),
             # The minutes since the bar started modulo 60
             minutes_elapsed=(elapsed.seconds / 60) % 60,
             # The hours since the bar started modulo 24

--- a/progressbar/widgets.py
+++ b/progressbar/widgets.py
@@ -116,16 +116,45 @@ class TimeSensitiveWidgetBase(WidgetBase):
     INTERVAL = datetime.timedelta(seconds=1)
 
 
-class Timer(FormatWidgetMixin, TimeSensitiveWidgetBase):
+def _format_time(seconds):
+    '''Formats time as the string "HH:MM:SS".'''
+    return str(datetime.timedelta(seconds=int(seconds)))
+
+
+class FormatLabel(FormatWidgetMixin):
+    '''Displays a formatted label'''
+
+    mapping = {
+        'finished': ('end_time', None),
+        'last_update': ('last_update_time', None),
+        'max': ('max_value', None),
+        'seconds': ('seconds_elapsed', None),
+        'start': ('start_time', None),
+        'elapsed': ('total_seconds_elapsed', _format_time),
+        'value': ('value', None),
+    }
+
+    def __call__(self, progress, data):
+        for name, (key, transform) in self.mapping.items():
+            try:
+                if transform is None:
+                    data[name] = data[key]
+                else:
+                    data[name] = transform(data[key])
+            except:  # pragma: no cover
+                pass
+
+        return FormatWidgetMixin.__call__(self, progress, data)
+
+
+class Timer(FormatLabel, TimeSensitiveWidgetBase):
     '''WidgetBase which displays the elapsed seconds.'''
 
-    def __init__(self, format='Elapsed Time: %(time_elapsed)s'):
+    def __init__(self, format='Elapsed Time: %(elapsed)s'):
         super(Timer, self).__init__(format=format)
 
-    @staticmethod
-    def format_time(seconds):
-        '''Formats time as the string "HH:MM:SS".'''
-        return str(datetime.timedelta(seconds=int(seconds)))
+    # This is exposed as a static method for backwards compatibility
+    format_time = staticmethod(_format_time)
 
 
 class SamplesMixin(object):
@@ -312,37 +341,6 @@ class Percentage(FormatWidgetMixin, WidgetBase):
 
     def __init__(self, format='%(percentage)3d%%'):
         super(Percentage, self).__init__(format=format)
-
-
-class FormatLabel(Timer):
-
-    '''Displays a formatted label'''
-
-    mapping = {
-        'elapsed': ('seconds_elapsed', Timer.format_time),
-        'finished': ('end_time', None),
-        'last_update': ('last_update_time', None),
-        'max': ('max_value', None),
-        'seconds': ('seconds_elapsed', None),
-        'start': ('start_time', None),
-        'elapsed': ('total_seconds_elapsed', Timer.format_time),
-        'value': ('value', None),
-    }
-
-    def __init__(self, format):
-        self.format = format
-
-    def __call__(self, progress, data):
-        for name, (key, transform) in self.mapping.items():
-            try:
-                if transform is None:
-                    data[name] = data[key]
-                else:
-                    data[name] = transform(data[key])
-            except:  # pragma: no cover
-                pass
-
-        return FormatWidgetMixin.__call__(self, progress, data)
 
 
 class SimpleProgress(FormatWidgetMixin, WidgetBase):

--- a/progressbar/widgets.py
+++ b/progressbar/widgets.py
@@ -191,7 +191,7 @@ class ETA(Timer):
         if value == progress.min_value:
             return 'ETA:  --:--:--'
         elif progress.end_time:
-            return 'Time: %s' % elapsed
+            return 'Time: %.2f' % data['total_seconds_elapsed']
         else:
             eta = elapsed * progress.max_value / value - elapsed
             return 'ETA: %s' % self.format_time(eta)


### PR DESCRIPTION
Before, with the default widgets:

```
$ python3 progress.py 
100% (60 of 60) |########| Elapsed Time: 0:00:06.027589 Time: 0.9040819999999999
```

After:

```
$ python3 progress.py 
100% (60 of 60) |#############################| Elapsed Time: 0:00:06 Time: 6.03
```

Specific changes:

- Hide the microseconds in the `Timer` class. They're either updating too fast to read, or they're out of date by the time you read them anyway. This required some rearranging to make Timer inherit from FormatLabel.
- Fix AdaptiveETA's display of the total elapsed time after progress is finished (see the 'before' example, it says ~0.9 when it should say ~6.0).
- Limit ETA and AdaptiveETA's display of the total elapsed time to 2 decimal places. This was fairly arbitrary, but showing the full floating point precision is clearly not helpful.
- Fix the calculation of `seconds_elapsed` - microseconds were being added to seconds without scaling them.