### PR TITLE
Fixes for UnknownLength handling

### DIFF
--- a/progressbar/__init__.py
+++ b/progressbar/__init__.py
@@ -62,7 +62,7 @@ from progressbar.widgets import (
     RotatingMarker,
 )
 
-from .bar import ProgressBar
+from .bar import ProgressBar, DataTransferBar
 from .base import UnknownLength
 
 
@@ -91,6 +91,7 @@ __all__ = [
     'BouncingBar',
     'UnknownLength',
     'ProgressBar',
+    'DataTransferBar',
     'format_updatable',
     'RotatingMarker',
 ]

--- a/progressbar/bar.py
+++ b/progressbar/bar.py
@@ -322,9 +322,8 @@ class ProgressBar(StdRedirectMixin, ResizableMixin, ProgressBarBase):
             ]
         else:
             return [
-                widgets.Percentage(),
-                ' (', widgets.SimpleProgress(), ')',
-                ' ', widgets.Bar(),
+                widgets.AnimatedMarker(),
+                ' ', widgets.Counter(),
                 ' ', widgets.Timer(),
             ]
 

--- a/progressbar/bar.py
+++ b/progressbar/bar.py
@@ -193,7 +193,7 @@ class ProgressBar(StdRedirectMixin, ResizableMixin, ProgressBarBase):
                                  'value')
         self.min_value = min_value
         self.max_value = max_value
-        self.widgets = widgets or self.default_widgets()
+        self.widgets = widgets
         self.left_justify = left_justify
 
         self._iterable = None
@@ -209,13 +209,6 @@ class ProgressBar(StdRedirectMixin, ResizableMixin, ProgressBarBase):
             poll_interval = timedelta(seconds=poll_interval)
 
         self.poll_interval = poll_interval
-        for widget in self.widgets:
-            interval = getattr(widget, 'INTERVAL', None)
-            if interval is not None:
-                self.poll_interval = min(
-                    self.poll_interval or interval,
-                    interval,
-                )
 
     @property
     def percentage(self):
@@ -465,6 +458,18 @@ class ProgressBar(StdRedirectMixin, ResizableMixin, ProgressBarBase):
         self.max_value = max_value or self.max_value
         if self.max_value is None:
             self.max_value = self._DEFAULT_MAXVAL
+
+        # Constructing the default widgets is only done when we know max_value
+        if self.widgets is None:
+            self.widgets = self.default_widgets()
+
+        for widget in self.widgets:
+            interval = getattr(widget, 'INTERVAL', None)
+            if interval is not None:
+                self.poll_interval = min(
+                    self.poll_interval or interval,
+                    interval,
+                )
 
         self.num_intervals = max(100, self.term_width)
         self.next_update = 0

--- a/progressbar/bar.py
+++ b/progressbar/bar.py
@@ -492,3 +492,27 @@ class ProgressBar(StdRedirectMixin, ResizableMixin, ProgressBarBase):
 
         super(ProgressBar, self).finish()
 
+
+class DataTransferBar(ProgressBar):
+    '''A progress bar with sensible defaults for downloads etc.
+
+    This assumes that the values its given are numbers of bytes.
+    '''
+    # Base class defaults to 100, but that makes no sense here
+    _DEFAULT_MAXVAL = base.UnknownLength
+
+    def default_widgets(self):
+        if self.max_value:
+            return [
+                widgets.Percentage(),
+                ' of ', widgets.DataSize('max_value'),
+                ' ', widgets.Bar(),
+                ' ', widgets.Timer(),
+                ' ', widgets.AdaptiveETA(),
+            ]
+        else:
+            return [
+                widgets.AnimatedMarker(),
+                ' ', widgets.DataSize(),
+                ' ', widgets.Timer(),
+            ]

--- a/progressbar/base.py
+++ b/progressbar/base.py
@@ -1,3 +1,6 @@
+from .six import with_metaclass
+
+
 class FalseMeta(type):
     def __bool__(self):  # pragma: no cover
         return False
@@ -8,5 +11,5 @@ class FalseMeta(type):
     __nonzero__ = __bool__
 
 
-class UnknownLength(object):
-    __metaclass__ = FalseMeta
+class UnknownLength(with_metaclass(FalseMeta, object)):
+    pass

--- a/progressbar/six.py
+++ b/progressbar/six.py
@@ -21,3 +21,37 @@ if PY3:  # pragma: no cover
 else:  # pragma: no cover
     import __builtin__
     basestring = __builtin__.basestring
+
+# Copied from the public six library: -----------------------------------------
+
+# Copyright (c) 2010-2015 Benjamin Peterson
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+
+def with_metaclass(meta, *bases):
+    """Create a base class with a metaclass."""
+    # This requires a bit of explanation: the basic idea is to make a dummy
+    # metaclass for one level of class instantiation that replaces itself with
+    # the actual metaclass.
+    class metaclass(meta):
+
+        def __new__(cls, name, this_bases, d):
+            return meta(name, bases, d)
+    return type.__new__(metaclass, 'temporary_class', (), {})

--- a/progressbar/widgets.py
+++ b/progressbar/widgets.py
@@ -192,7 +192,8 @@ class ETA(Timer):
         elif progress.end_time:
             return 'Time: %.2f' % data['total_seconds_elapsed']
         else:
-            eta = elapsed * progress.max_value / value - data['total_seconds_elapsed']
+            eta = elapsed * progress.max_value / value \
+                - data['total_seconds_elapsed']
             return 'ETA: %s' % self.format_time(eta)
 
     def __call__(self, progress, data):

--- a/progressbar/widgets.py
+++ b/progressbar/widgets.py
@@ -251,14 +251,16 @@ class DataSize(FormatWidgetMixin):
     appropriate sized unit, based on the IEC binary prefixes (powers of 1024).
     '''
     def __init__(
-            self, format='%(scaled)5.1f %(prefix)s%(unit)s', unit='B',
+            self, variable='value',
+            format='%(scaled)5.1f %(prefix)s%(unit)s', unit='B',
             prefixes=('', 'Ki', 'Mi', 'Gi', 'Ti', 'Pi', 'Ei', 'Zi', 'Yi')):
+        self.variable = variable
         self.unit = unit
         self.prefixes = prefixes
         super(DataSize, self).__init__(format=format)
 
     def __call__(self, progress, data):
-        value = data['value']
+        value = data[self.variable]
         if value is not None:
             scaled, power = utils.scale_1024(value, len(self.prefixes))
         else:

--- a/progressbar/widgets.py
+++ b/progressbar/widgets.py
@@ -192,7 +192,7 @@ class ETA(Timer):
         elif progress.end_time:
             return 'Time: %.2f' % data['total_seconds_elapsed']
         else:
-            eta = elapsed * progress.max_value / value - elapsed
+            eta = elapsed * progress.max_value / value - data['total_seconds_elapsed']
             return 'ETA: %s' % self.format_time(eta)
 
     def __call__(self, progress, data):

--- a/tests/datatransferbar.py
+++ b/tests/datatransferbar.py
@@ -1,0 +1,16 @@
+import progressbar
+from progressbar import DataTransferBar
+
+
+def test_known_length():
+    dtb = DataTransferBar().start(max_value=50)
+    for i in range(50):
+        dtb.update(i)
+    dtb.finish()
+
+
+def test_unknown_length():
+    dtb = DataTransferBar().start(max_value=progressbar.UnknownLength)
+    for i in range(50):
+        dtb.update(i)
+    dtb.finish()

--- a/tests/iterators.py
+++ b/tests/iterators.py
@@ -20,9 +20,11 @@ def test_iterator_with_max_value():
 def test_iterator_without_max_value_error():
     '''Progressbar can't guess max_value.'''
     p = progressbar.ProgressBar()
-    with pytest.raises(TypeError):
-        for i in p((i for i in range(10))):
-            time.sleep(0.001)
+
+    for i in p((i for i in range(10))):
+        time.sleep(0.001)
+
+    assert p.max_value is progressbar.UnknownLength
 
 
 def test_iterator_without_max_value():

--- a/tests/unknownlength.py
+++ b/tests/unknownlength.py
@@ -14,3 +14,14 @@ def test_unknown_length_default_widgets():
     for i in range(60):
         pb.update(i)
     pb.finish()
+
+
+def test_unknown_length_at_start():
+    # The default widgets should be picked after we call .start()
+    pb = ProgressBar().start(max_value=UnknownLength)
+    for i in range(60):
+        pb.update(i)
+    pb.finish()
+
+    pb2 = ProgressBar().start(max_value=UnknownLength)
+    assert any([isinstance(w, progressbar.Bar) for w in pb2.widgets])

--- a/tests/unknownlength.py
+++ b/tests/unknownlength.py
@@ -1,0 +1,7 @@
+import progressbar
+
+
+def test_unknown_length():
+    pb = progressbar.ProgressBar(widgets=[progressbar.AnimatedMarker()],
+                                 max_value=progressbar.UnknownLength)
+    assert pb.max_value is progressbar.UnknownLength

--- a/tests/unknownlength.py
+++ b/tests/unknownlength.py
@@ -1,7 +1,16 @@
 import progressbar
+from progressbar import ProgressBar, UnknownLength
 
 
 def test_unknown_length():
-    pb = progressbar.ProgressBar(widgets=[progressbar.AnimatedMarker()],
-                                 max_value=progressbar.UnknownLength)
-    assert pb.max_value is progressbar.UnknownLength
+    pb = ProgressBar(widgets=[progressbar.AnimatedMarker()],
+                     max_value=UnknownLength)
+    assert pb.max_value is UnknownLength
+
+
+def test_unknown_length_default_widgets():
+    # The default widgets picked should work without a known max_value
+    pb = ProgressBar(max_value=UnknownLength).start()
+    for i in range(60):
+        pb.update(i)
+    pb.finish()


### PR DESCRIPTION
A few fixes for using `UnknownLength` to have a progress indicator with an unspecified maximum:

* Instantiating `ProgressBar(max_value=UnknownLength)` failed entirely on Python 3, because the UnknownLength class wasn't seen as False-y. Fixed the metaclass definition of UnknownLength.
* When the maximum value is unknown, the default widgets used must not rely on max_value, so e.g. `Percentage()` won't work. I've picked AnimatedMarker, Counter and Timer.
* `max_value` can be passed to the start method, so I delayed constructing the default widgets until start() is called. This makes these equivalent:

```python
ProgressBar(max_value=n).start()
ProgressBar().start(max_value=n)
```

And a couple of extra changes:

* I added a `DataTransferBar` subclass of `ProgressBar`, which has sensible defaults for downloads, uploads, etc., as I imagine these are very common use cases for progress bars. This features the DataSize widget I recently added.
* I noticed that the AdaptiveETA indicator was showing a roughly constant time instead of decreasing. It was subtracting the sampling period from the total time estimate, instead of the total time elapsed. I fixed this, and in manual testing, it does now count down. It's still rather flickery, but that's a separate issue.