### PR TITLE
Fix python 3 unorderable types error in FileTransferSpeed

### DIFF
--- a/progressbar/widgets.py
+++ b/progressbar/widgets.py
@@ -297,7 +297,7 @@ class FileTransferSpeed(FormatWidgetMixin, TimeSensitiveWidgetBase):
         value = data['value'] or value
         elapsed = data['total_seconds_elapsed'] or total_seconds_elapsed
 
-        if value is not None and elapsed > 2e-6 and value > 2e-6:  # =~ 0
+        if value is not None and elapsed is not None and elapsed > 2e-6 and value > 2e-6:  # =~ 0
             scaled, power = self._speed(value, elapsed)
         else:
             scaled = power = 0

--- a/progressbar/widgets.py
+++ b/progressbar/widgets.py
@@ -297,7 +297,8 @@ class FileTransferSpeed(FormatWidgetMixin, TimeSensitiveWidgetBase):
         value = data['value'] or value
         elapsed = data['total_seconds_elapsed'] or total_seconds_elapsed
 
-        if value is not None and elapsed is not None and elapsed > 2e-6 and value > 2e-6:  # =~ 0
+        if value is not None and elapsed is not None \
+                and elapsed > 2e-6 and value > 2e-6:  # =~ 0
             scaled, power = self._speed(value, elapsed)
         else:
             scaled = power = 0


### PR DESCRIPTION
I've got following error on python 3.5 (windows x64), and made small workaround.
```
  File "C:\env\Python35\lib\site-packages\progressbar\bar.py", line 442, in update
    super(ProgressBar, self).update(value=value)
  File "C:\env\Python35\lib\site-packages\progressbar\bar.py", line 100, in update
    super(StdRedirectMixin, self).update(value=value)
  File "C:\env\Python35\lib\site-packages\progressbar\bar.py", line 41, in update
    self.fd.write('\r' + self._format_line())
  File "C:\env\Python35\lib\site-packages\progressbar\bar.py", line 401, in _format_line
    widgets = ''.join(self._format_widgets())
  File "C:\env\Python35\lib\site-packages\progressbar\bar.py", line 381, in _format_widgets
    widget_output = widget(self, data)
  File "C:\env\Python35\lib\site-packages\progressbar\widgets.py", line 300, in __call__
    if value is not None and elapsed > 2e-6 and value > 2e-6:  # =~ 0
TypeError: unorderable types: NoneType() > float()
```