### PR TITLE
Multiple fixes in utils.get_terminal_size()

### DIFF
--- a/progressbar/utils.py
+++ b/progressbar/utils.py
@@ -49,15 +49,15 @@ def get_terminal_size():  # pragma: no cover
     function but that's never really possible with cross-platform code.
 
     Returns:
-        height, width: Two integers containing height and width
+        width, height: Two integers containing width and height
     '''
     try:
         # This works for Python 3, but not Pypy3. Probably the best method if
         # it's supported so let's always try
         import shutil
-        h, w = shutil.get_terminal_size((0, 0))
+        w, h = shutil.get_terminal_size()
         if w and h:
-            return h, w
+            return w, h
     except:  # pragma: no cover
         pass
 
@@ -65,43 +65,44 @@ def get_terminal_size():  # pragma: no cover
         w = int(os.environ.get('COLUMNS'))
         h = int(os.environ.get('LINES'))
         if w and h:
-            return h, w
+            return w, h
     except:  # pragma: no cover
         pass
 
     try:
         import blessings
         terminal = blessings.Terminal()
-        h, w = terminal._height_and_width
+        w = terminal.width
+        h = terminal.height
         if w and h:
-            return h, w
+            return w, h
     except:  # pragma: no cover
         pass
 
     try:
-        h, w = _get_terminal_size_linux()
+        w, h = _get_terminal_size_linux()
         if w and h:
-            return h, w
+            return w, h
     except:  # pragma: no cover
         pass
 
     try:
         # Windows detection doesn't always work, let's try anyhow
-        h, w = _get_terminal_size_windows()
+        w, h = _get_terminal_size_windows()
         if w and h:
-            return h, w
+            return w, h
     except:  # pragma: no cover
         pass
 
     try:
         # needed for window's python in cygwin's xterm!
-        h, w = _get_terminal_size_tput()
+        w, h = _get_terminal_size_tput()
         if w and h:
-            return h, w
+            return w, h
     except:  # pragma: no cover
         pass
 
-    return 80, 25
+    return 80, 24
 
 
 def _get_terminal_size_windows():  # pragma: no cover


### PR DESCRIPTION
* change docstring to reflect reality
* shutil.get_terminal_size() - dimensions order was correct, only names were misleading
* os.environ.get('COLUMNS/LINES') - dimensions order was incorrect
* blessings - _height_and_width is private method, not property; replace with property access and fix order
* _get_terminal_size_* - fix dimensions order
* 80, 24 - correct default terminal height (shutil.get_terminal_size also returns it as fallback)