### PR TITLE
Make bdist_wheel universal

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -28,3 +28,5 @@ all_files  = 1
 [upload_sphinx]
 upload-dir = docs/_build/html
 
+[bdist_wheel]
+universal=1


### PR DESCRIPTION
Though it seems to be fixed now on PyPi, one of the previous wheels was not built as universal (was py2 only). To prevent this from happening in the future, adding `universal` under `[bdist_wheel]` makes `python setup.py bdist_wheel` always build a universal wheel.