### PR TITLE
restore, rather than overwrite, sigwinch signal

### DIFF
--- a/progressbar/bar.py
+++ b/progressbar/bar.py
@@ -63,6 +63,7 @@ class ResizableMixin(ProgressBarMixinBase):
             try:
                 self._handle_resize()
                 import signal
+                self._prev_handle = signal.getsignal(signal.SIGWINCH)
                 signal.signal(signal.SIGWINCH, self._handle_resize)
                 self.signal_set = True
             except Exception:  # pragma: no cover
@@ -79,7 +80,7 @@ class ResizableMixin(ProgressBarMixinBase):
         if self.signal_set:
             try:
                 import signal
-                signal.signal(signal.SIGWINCH, signal.SIG_DFL)
+                signal.signal(signal.SIGWINCH, self._prev_handle)
             except Exception:  # pragma no cover
                 pass
 


### PR DESCRIPTION
This is to allow nested progressbar to handle window resize properly.

Consider the following case,
```
bar1 = progressbar.ProgressBar(max_value=1000).start()
for i in range(1000):
   bar1.update(i)
   if i % 100 == 0:
       bar2 = progressbar.ProgressBar(max_value=100).start()
       for j in range(100):
           bar2.update(j)
```

without the fix, bar1 will not be able to resize.