### PR TITLE
Check for Jupyter Notebook before allocating other terminal sizes.

### DIFF
--- a/progressbar/utils.py
+++ b/progressbar/utils.py
@@ -106,6 +106,16 @@ def get_terminal_size():  # pragma: no cover
     Returns:
         width, height: Two integers containing width and height
     '''
+    
+    try:
+        # Default to 79 characters for IPython notebooks
+        ipython = globals().get('get_ipython')()
+        from ipykernel import zmqshell
+        if isinstance(ipython, zmqshell.ZMQInteractiveShell):
+            return 79, 24
+    except Exception:  # pragma: no cover
+        pass
+    
     try:
         # This works for Python 3, but not Pypy3. Probably the best method if
         # it's supported so let's always try
@@ -133,15 +143,6 @@ def get_terminal_size():  # pragma: no cover
         h = terminal.height
         if w and h:
             return w, h
-    except Exception:  # pragma: no cover
-        pass
-
-    try:
-        # Default to 79 characters for IPython notebooks
-        ipython = globals().get('get_ipython')()
-        from ipykernel import zmqshell
-        if isinstance(ipython, zmqshell.ZMQInteractiveShell):
-            return 79, 24
     except Exception:  # pragma: no cover
         pass
 

--- a/progressbar/utils.py
+++ b/progressbar/utils.py
@@ -106,7 +106,7 @@ def get_terminal_size():  # pragma: no cover
     Returns:
         width, height: Two integers containing width and height
     '''
-    
+
     try:
         # Default to 79 characters for IPython notebooks
         ipython = globals().get('get_ipython')()
@@ -115,7 +115,7 @@ def get_terminal_size():  # pragma: no cover
             return 79, 24
     except Exception:  # pragma: no cover
         pass
-    
+
     try:
         # This works for Python 3, but not Pypy3. Probably the best method if
         # it's supported so let's always try


### PR DESCRIPTION
Currently, the number of columns and rows used by `progressbar2` in Jupyter notebooks is inherited from the shell from which it was run... which leads to some pretty weird behaviour. Instead, I think we should check for Jupyter notebooks first.

Is there ever a case where this doesn't make sense?

@WoLpH 