### PR TITLE
Fix unwrapping stdout/stderr

### DIFF
--- a/progressbar/utils.py
+++ b/progressbar/utils.py
@@ -57,16 +57,18 @@ class StreamWrapper(object):
             self.unwrap_stderr()
 
     def unwrap_stdout(self):
-        if self.wrapped_stdout > 0:
+        if self.wrapped_stdout > 1:
             self.wrapped_stdout -= 1
         else:
             sys.stdout = self.original_stdout
+            self.wrapped_stdout = 0
 
     def unwrap_stderr(self):
-        if self.wrapped_stderr > 0:
+        if self.wrapped_stderr > 1:
             self.wrapped_stderr -= 1
         else:
             sys.stderr = self.original_stderr
+            self.wrapped_stderr = 0
 
     def flush(self):
         if self.wrapped_stdout:

--- a/tests/test_stream.py
+++ b/tests/test_stream.py
@@ -1,3 +1,4 @@
+import io
 import sys
 import progressbar
 
@@ -38,3 +39,11 @@ def test_wrap():
     progressbar.streams.unwrap(stderr=True, stdout=True)
     progressbar.streams.unwrap(stderr=True, stdout=True)
     progressbar.streams.unwrap(stderr=True, stdout=True)
+
+
+def test_fd_as_io_stream():
+    stream = io.StringIO()
+    with progressbar.ProgressBar(fd=stream) as pb:
+        for i in range(101):
+            pb.update(i)
+    stream.close()


### PR DESCRIPTION
Hi @WoLpH,

Looks like you've got a couple of off-by-one errors here, which leads to the stdout/stderr not being restored appropriately. Causing some bugs downstream :).