### PR TITLE
Use get_ipython imported from IPython rather than global namespace

### DIFF
--- a/progressbar/utils.py
+++ b/progressbar/utils.py
@@ -157,7 +157,8 @@ def get_terminal_size():  # pragma: no cover
 
     try:
         # Default to 79 characters for IPython notebooks
-        ipython = globals().get('get_ipython')()
+        from IPython import get_ipython
+        ipython = get_ipython()
         from ipykernel import zmqshell
         if isinstance(ipython, zmqshell.ZMQInteractiveShell):
             return 79, 24


### PR DESCRIPTION
Upstream IPython discourages using `get_ipython` from global namespace, and it seems not to be present in newer notebook versions, leading to poor choice of terminal width.