### PR TITLE
fixes #122

### DIFF
--- a/progressbar/widgets.py
+++ b/progressbar/widgets.py
@@ -416,8 +416,13 @@ class FileTransferSpeed(FormatWidgetMixin, TimeSensitiveWidgetBase):
 
     def __call__(self, progress, data, value=None, total_seconds_elapsed=None):
         '''Updates the widget with the current SI prefixed speed.'''
-        value = data['value'] or value
-        elapsed = data['total_seconds_elapsed'] or total_seconds_elapsed
+        if value is None:
+            value = data['value']
+
+        if total_seconds_elapsed is None:
+            elapsed = data['total_seconds_elapsed']
+        else:
+            elapsed = total_seconds_elapsed
 
         if value is not None and elapsed is not None \
                 and elapsed > 2e-6 and value > 2e-6:  # =~ 0


### PR DESCRIPTION
It would be nicer to rename `total_seconds_elapsed` to elapsed as in
`ETA` but this solution does not break the interface. Also this solution
follows `ETA` and uses values from data if and only if `value` or
`total_seconds_elapsed` is Null.