### PR TITLE
Convert extraneous print statement to `logger.debug` call.

### DIFF
--- a/progressbar/utils.py
+++ b/progressbar/utils.py
@@ -62,7 +62,7 @@ class StreamWrapper(object):
 
     def wrap_excepthook(self):
         if not self.wrapped_excepthook:
-            print('wrapping excepthook')
+            logger.debug('wrapping excepthook')
             self.wrapped_excepthook += 1
             sys.excepthook = self.excepthook
 


### PR DESCRIPTION
Hello. Just noticed this `print()` statement here that probably should be a logger call.
