### PR TITLE
Removed python-utils dependency

### DIFF
--- a/progressbar/bar.py
+++ b/progressbar/bar.py
@@ -11,8 +11,6 @@ import warnings
 from datetime import datetime, timedelta
 import collections
 
-from python_utils import converters
-
 import six
 
 from . import widgets
@@ -57,7 +55,7 @@ class DefaultFdMixin(ProgressBarMixinBase):
 
     def update(self, *args, **kwargs):
         ProgressBarMixinBase.update(self, *args, **kwargs)
-        line = converters.to_unicode('\r' + self._format_line())
+        line = utils.to_unicode('\r' + self._format_line())
         self.fd.write(line)
 
     def finish(self, *args, **kwargs):  # pragma: no cover
@@ -473,7 +471,7 @@ class ProgressBar(StdRedirectMixin, ResizableMixin, ProgressBarBase):
                 result.append(widget)
                 width -= self.custom_len(widget)
             else:
-                widget_output = converters.to_unicode(widget(self, data))
+                widget_output = utils.to_unicode(widget(self, data))
                 result.append(widget_output)
                 width -= self.custom_len(widget_output)
 
@@ -493,7 +491,7 @@ class ProgressBar(StdRedirectMixin, ResizableMixin, ProgressBarBase):
     @classmethod
     def _to_unicode(cls, args):
         for arg in args:
-            yield converters.to_unicode(arg)
+            yield utils.to_unicode(arg)
 
     def _format_line(self):
         'Joins the widgets and justifies the line'

--- a/progressbar/utils.py
+++ b/progressbar/utils.py
@@ -386,8 +386,8 @@ def format_time(tval, precision=datetime.timedelta(seconds=1)):
 
     if isinstance(tval, six.string_types + six.integer_types + (float, )):
         try:
-            tval = datetime.timedelta(seconds=(long(tval) if six.PY2
-                                               else int(tval)))
+            castfunc = long if six.PY2 else int  # NOQA
+            tval = datetime.timedelta(seconds=castfunc(tval))
         except OverflowError:  # pragma: no cover
             tval = None
 

--- a/progressbar/utils.py
+++ b/progressbar/utils.py
@@ -424,3 +424,11 @@ def timestamp(dt):  # pragma: no cover
         return dt.timestamp()
     else:
         return (dt - epoch).total_seconds()
+
+
+def to_unicode(value):
+    '''Convert objects to unicode'''
+    if isinstance(value, six.binary_type):
+        return value.decode('utf-8', 'replace')
+    return six.text_type(value)
+

--- a/progressbar/utils.py
+++ b/progressbar/utils.py
@@ -431,4 +431,3 @@ def to_unicode(value):
     if isinstance(value, six.binary_type):
         return value.decode('utf-8', 'replace')
     return six.text_type(value)
-

--- a/progressbar/widgets.py
+++ b/progressbar/widgets.py
@@ -9,8 +9,6 @@ import datetime
 import pprint
 import sys
 
-from python_utils import converters
-
 import six
 
 from . import base
@@ -41,7 +39,7 @@ def create_marker(marker):
             return marker
 
     if isinstance(marker, six.string_types):
-        marker = converters.to_unicode(marker)
+        marker = utils.to_unicode(marker)
         assert len(marker) == 1, 'Markers are required to be 1 char'
         return _marker
     else:
@@ -586,11 +584,11 @@ class Bar(AutoWidthWidgetBase):
     def __call__(self, progress, data, width):
         '''Updates the progress bar and its subcomponents'''
 
-        left = converters.to_unicode(self.left(progress, data, width))
-        right = converters.to_unicode(self.right(progress, data, width))
+        left = utils.to_unicode(self.left(progress, data, width))
+        right = utils.to_unicode(self.right(progress, data, width))
         width -= progress.custom_len(left) + progress.custom_len(right)
-        marker = converters.to_unicode(self.marker(progress, data, width))
-        fill = converters.to_unicode(self.fill(progress, data, width))
+        marker = utils.to_unicode(self.marker(progress, data, width))
+        fill = utils.to_unicode(self.fill(progress, data, width))
 
         if self.fill_left:
             marker = marker.ljust(width, fill)
@@ -625,12 +623,12 @@ class BouncingBar(Bar, TimeSensitiveWidgetBase):
     def __call__(self, progress, data, width):
         '''Updates the progress bar and its subcomponents'''
 
-        left = converters.to_unicode(self.left(progress, data, width))
-        right = converters.to_unicode(self.right(progress, data, width))
+        left = utils.to_unicode(self.left(progress, data, width))
+        right = utils.to_unicode(self.right(progress, data, width))
         width -= progress.custom_len(left) + progress.custom_len(right)
-        marker = converters.to_unicode(self.marker(progress, data, width))
+        marker = utils.to_unicode(self.marker(progress, data, width))
 
-        fill = converters.to_unicode(self.fill(progress, data, width))
+        fill = utils.to_unicode(self.fill(progress, data, width))
 
         if width:  # pragma: no branch
             value = int(

--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,6 @@ if __name__ == '__main__':
         long_description=readme,
         include_package_data=True,
         install_requires=[
-            'python-utils>=2.1.0',
             'six',
         ],
         tests_require=tests_reqs,

--- a/tests/test_unicode.py
+++ b/tests/test_unicode.py
@@ -3,7 +3,14 @@
 import time
 import pytest
 import progressbar
-from python_utils import converters
+
+import six
+
+
+def _to_str(value):
+    if isinstance(value, six.binary_type):
+        return value
+    return value.encode('utf-8', 'replace')
 
 
 @pytest.mark.parametrize('name,markers', [
@@ -14,9 +21,9 @@ from python_utils import converters
 @pytest.mark.parametrize('as_unicode', [True, False])
 def test_markers(name, markers, as_unicode):
     if as_unicode:
-        markers = converters.to_unicode(markers)
+        markers = progressbar.utils.to_unicode(markers)
     else:
-        markers = converters.to_str(markers)
+        markers = _to_str(markers)
 
     widgets = [
         '%s: ' % name.capitalize(),

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -7,6 +7,8 @@ import progressbar.utils
 @pytest.mark.parametrize('val,expected', [('abc', u'abc'),
                                           (u'←', u'←'),
                                           (u'◢', u'◢'),
+                                          (b'abc', u'abc'),
+                                          (r'c:\dir', u'c:\\dir'),
                                           (None, u"None")])
 def test_to_unicode(val, expected):
     result = progressbar.utils.to_unicode(val)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,14 @@
+# -*- mode: python; coding: utf-8 -*-
+import six
+import pytest
+import progressbar.utils
+
+
+@pytest.mark.parametrize('val,expected', [('abc', u'abc'),
+                                          (u'←', u'←'),
+                                          (u'◢', u'◢'),
+                                          (None, u"None")])
+def test_to_unicode(val, expected):
+    result = progressbar.utils.to_unicode(val)
+    assert result == expected, result
+    assert isinstance(result, six.text_type), type(result)


### PR DESCRIPTION
This is based on my currently unmerged change #145 

The dep was only used for very simple string conversions and may prevent some people from using  progressbar.
After doing the changes I noticed that this will also fix #144.
