### PR TITLE
Add New Test Which Monitors Output

### DIFF
--- a/tests/test_monitor_progress.py
+++ b/tests/test_monitor_progress.py
@@ -1,0 +1,61 @@
+pytest_plugins = "pytester"
+
+
+def test_simple_example(testdir):
+    """ Run the simple example code in a python subprocess and then compare its
+        stderr to what we expect to see from it.  We run it in a subprocess to
+        best capture its stderr. We expect to see match_lines in order in the
+        output.  This test is just a sanity check to ensure that the progress
+        bar progresses from 1 to 10, it does not make sure that the """
+    v = testdir.makepyfile("""
+        import time
+        import progressbar
+
+        bar = progressbar.ProgressBar()
+        for i in bar(range(10)):
+            time.sleep(0.1)
+
+    """)
+    result = testdir.runpython(v)
+    result.stderr.re_match_lines([
+        " 10% \(1 of 10\)",
+        " 20% \(2 of 10\)",
+        " 30% \(3 of 10\)",
+        " 40% \(4 of 10\)",
+        " 50% \(5 of 10\)",
+        " 60% \(6 of 10\)",
+        " 70% \(7 of 10\)",
+        " 80% \(8 of 10\)",
+        " 90% \(9 of 10\)",
+        "100% \(10 of 10\)"
+    ])
+
+
+def test_rapid_updates(testdir):
+    """ Run some example code that updates 10 times, then sleeps .1 seconds,
+        this is meant to test that the progressbar progresses normally with
+        this sample code, since there were issues with it in the past """
+    v = testdir.makepyfile("""
+        import time
+        import progressbar
+
+        bar = progressbar.ProgressBar()
+        for i in bar(range(100)):
+            if i % 10 == 0:
+                time.sleep(0.1)
+
+    """)
+    result = testdir.runpython(v)
+    result.stderr.re_match_lines([
+        "  1% \(1 of 100\)",
+        " 11% \(11 of 100\)",
+        " 21% \(21 of 100\)",
+        " 31% \(31 of 100\)",
+        " 41% \(41 of 100\)",
+        " 51% \(51 of 100\)",
+        " 61% \(61 of 100\)",
+        " 71% \(71 of 100\)",
+        " 81% \(81 of 100\)",
+        " 91% \(91 of 100\)",
+        "100% \(100 of 100\)"
+    ])


### PR DESCRIPTION
I was not able to test this with 'tox'  I am not familiar with it.  I'll look into it a bit more, but wanted to get this out there for you to look at.


From Issue #154

> unfortunately this type of bug is hard to test for

I think I've setup two tests that can detect the two types of failures in #154,  I wasn't sure sure what to name the tests but I went with test_monitor_progress.py.  test_simple_example and test_rapid_updates

Hopefully this test is acceptable and can be the framework for more thorough tests in the future.  I think I could write a test for issue #155 even.

To validate my test I did the following

I went through and ran the tests for every tagged version in git.  I first tested if the simple script
``` python
import time
import progressbar

bar = progressbar.ProgressBar()
for i in bar(range(100)):
    time.sleep(0.02)
```
would run with a OK(return code 0 == YES).  Then I ran test_simple_example and then test_rapid_updates

Testing script
``` bash
for x in $(git log --tags --oneline --decorate --simplify-by-decoration | grep v[0-9] | awk '{print $3}' | awk -F\) '{print $1}'); do
    git checkout $x 2> /dev/null;
    python simple_example.py 2>/dev/null;
    if [ $? -ne 0 ]; then
        echo "$x    NO"
    else
        echo -n "$x    YES        "
        pytest tests/test_foo.py::test_foo -p pytester --override-ini=addopts= > /dev/null
        foo=$?
        pytest tests/test_foo.py::test_bar -p pytester --override-ini=addopts= > /dev/null
        bar=$?
        if [ $foo -eq 0 ] ; then
            echo -n "PASS    ";
        else
            echo -n "FAIL    ";
        fi;
        if [ $bar -eq 0 ] ; then
            echo "PASS";
        else
            echo "FAIL"
        fi;
    fi
done
```
I added some comments on why my test is faling on certain versions.
```
version    script   test_simple  test_rapid  comments
v3.35.2    YES        PASS    PASS
v3.35.1    YES        PASS    FAIL
v3.35.0    YES        FAIL    FAIL	Failure point for issue #154
v3.34.4    YES        PASS    PASS
v3.34.3    YES        PASS    PASS
v3.34.2    YES        PASS    PASS
v3.34.1    YES        PASS    PASS
v3.34.0    YES        PASS    PASS
v3.33.2    YES        PASS    PASS
v3.33.1    YES        PASS    PASS
v3.33.0    YES        PASS    PASS
v3.32.1    YES        PASS    PASS
v3.32.0    YES        PASS    PASS
v3.31.1    YES        PASS    PASS
v3.31.0    YES        PASS    PASS
v3.30.2    YES        PASS    PASS
v3.30.0    YES        PASS    FAIL	test_bar would reach "10 of 100" then jump to "100 of 100"
v3.20.2    YES        PASS    FAIL
v3.18.1    YES        PASS    FAIL
v3.20.1    YES        PASS    FAIL
v3.20.0    YES        PASS    FAIL	test_bar would reach "10 of 100" then jump to "100 of 100"
v3.18.0    YES        PASS    FAIL
v3.17.1    YES        PASS    FAIL
v3.17.0    NO
v3.16.0    NO
v3.16.1    YES        PASS    FAIL	test_bar would reach "10 of 100" then jump to "100 of 100"
v3.15.1    YES        PASS    FAIL
v3.15.0    YES        PASS    FAIL
v3.12.0    YES        FAIL    PASS	output was "80% ( 8 of 10)"  test expects like "80% (8 of 10)"
v3.10.1    YES        FAIL    FAIL	output was "80% ( 8 of 10)"  test expects like "80% (8 of 10)"
v3.10.0    YES        FAIL    FAIL
v3.9.4     YES        FAIL    FAIL
v3.9.3     YES        FAIL    FAIL
v3.8.1     YES        FAIL    FAIL
v3.9.1     YES        FAIL    FAIL
v3.9.0     YES        FAIL    FAIL
v3.8.0     YES        FAIL    FAIL
v3.7.0     YES        FAIL    FAIL
v3.6.1     YES        FAIL    FAIL
v3.6.0     YES        FAIL    FAIL
v3.5.2     YES        FAIL    FAIL
v3.5.1     YES        FAIL    FAIL
v3.5.0     YES        FAIL    FAIL
v3.4.3     YES        FAIL    FAIL
v3.4.2     YES        FAIL    FAIL
v3.4.1     YES        FAIL    FAIL
v3.4.0     YES        FAIL    FAIL      output was "80% ( 8 of 10)"  test expects like "80% (8 of 10)"
v3.3.3     NO
v3.3.2     YES        PASS    PASS
v3.3.1     YES        PASS    PASS
v3.3.0     YES        PASS    PASS
v3.2.0     YES        PASS    PASS
v3.1.0     YES        PASS    PASS
v3.0.1     YES        PASS    PASS
v2.6.2     YES        FAIL    FAIL      output was "80% |##### ..."  test expects like "80% (8 of 10)"
v2.6.1     YES        FAIL    FAIL      output was "80% |##### ..."  test expects like "80% (8 of 10)"
v2.3       NO
```