### PR TITLE
Fix WRAP_STDOUT/ERR

### DIFF
--- a/progressbar/utils.py
+++ b/progressbar/utils.py
@@ -175,5 +175,5 @@ class StreamWrapper(object):
         self.flush()
 
 
-streams = StreamWrapper()
 logger = logging.getLogger(__name__)
+streams = StreamWrapper()


### PR DESCRIPTION
`StreamWrapper.__init__` calls `self.wrap_stdout/err` which uses `logger`, so the global `logger` variable has to be initialized first.