### PR TITLE
Consider ANSI escape codes when calculating the text length

### DIFF
--- a/progressbar/__init__.py
+++ b/progressbar/__init__.py
@@ -1,6 +1,9 @@
 from datetime import date
 
-from .utils import streams
+from .utils import (
+    len_color,
+    streams
+)
 from .shortcuts import progressbar
 
 from .widgets import (
@@ -41,6 +44,7 @@ from .__about__ import (
 __date__ = str(date.today())
 __all__ = [
     'progressbar',
+    'len_color',
     'streams',
     'Timer',
     'ETA',

--- a/progressbar/bar.py
+++ b/progressbar/bar.py
@@ -230,9 +230,9 @@ class ProgressBar(StdRedirectMixin, ResizableMixin, ProgressBarBase):
     _DEFAULT_MAXVAL = base.UnknownLength
     _MINIMUM_UPDATE_INTERVAL = 0.05  # update up to a 20 times per second
 
-    def __init__(self, min_value=0, max_value=None,
-                 widgets=None, left_justify=True, initial_value=0,
-                 poll_interval=None, widget_kwargs=None, custom_len=len,
+    def __init__(self, min_value=0, max_value=None, widgets=None,
+                 left_justify=True, initial_value=0, poll_interval=None,
+                 widget_kwargs=None, custom_len=utils.len_color,
                  max_error=True, prefix=None, suffix=None, **kwargs):
         '''
         Initializes a progress bar with sane defaults

--- a/progressbar/utils.py
+++ b/progressbar/utils.py
@@ -20,7 +20,7 @@ assert epoch
 
 def len_color(text):
     '''Return the length of text without ANSI escape codes'''
-    return len(re.sub(u'\u001b\[.*?[@-~]', '', text))
+    return len(re.sub(u'\u001b\\[.*?[@-~]', '', text))
 
 
 class WrappingIO:

--- a/progressbar/utils.py
+++ b/progressbar/utils.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 import io
 import os
+import re
 import sys
 import logging
 from python_utils.time import timedelta_to_seconds, epoch, format_time
@@ -15,6 +16,11 @@ assert get_terminal_size
 assert format_time
 assert scale_1024
 assert epoch
+
+
+def len_color(text):
+    '''Return the length of text without ANSI escape codes'''
+    return len(re.sub(u'\u001b\[.*?[@-~]', '', text))
 
 
 class WrappingIO:


### PR DESCRIPTION
This patch will ignore ANSI escape codes when calculating the length of the string.

E.g. the string `\033[96mtest\033[0m` has the length `4` instead of `13`. (`\033` is one character.)