### PR TITLE
Do not send garbage when the output is not a terminal

### DIFF
--- a/examples.py
+++ b/examples.py
@@ -72,6 +72,17 @@ def basic_widget_example():
 
 
 @example
+def color_bar_example():
+    widgets = ['\x1b[33mColorful example\x1b[39m', progressbar.Percentage(), progressbar.Bar(marker='\x1b[32m#\x1b[39m')]
+    bar = progressbar.ProgressBar(widgets=widgets, max_value=10).start()
+    for i in range(10):
+        # do something
+        time.sleep(0.1)
+        bar.update(i + 1)
+    bar.finish()
+
+
+@example
 def file_transfer_example():
     widgets = [
         'Test: ', progressbar.Percentage(),

--- a/examples.py
+++ b/examples.py
@@ -459,7 +459,7 @@ def eta():
 
 
 @example
-def dynamic_message():
+def variables():
     # Use progressbar.Variable to keep track of some parameter(s) during
     # your calculations
     widgets = [

--- a/progressbar/bar.py
+++ b/progressbar/bar.py
@@ -69,23 +69,25 @@ class DefaultFdMixin(ProgressBarMixinBase):
         # Check if this is an interactive terminal
         if is_terminal is None:
             is_terminal = utils.env_flag('PROGRESSBAR_IS_TERMINAL', None)
-        if is_terminal is None:
+        if is_terminal is None:  # pragma: no cover
             try:
                 is_terminal = fd.isatty()
-            except:
+            except Exception:
                 is_terminal = False
         self.is_terminal = is_terminal
 
-        # Check if it should overwrite the current line (suitable for iteractive terminals)
-        # or write line breaks (suitable for log files)
+        # Check if it should overwrite the current line (suitable for
+        # iteractive terminals) or write line breaks (suitable for log files)
         if line_breaks is None:
-            line_breaks = utils.env_flag('PROGRESSBAR_LINE_BREAKS', not is_terminal)
+            line_breaks = utils.env_flag('PROGRESSBAR_LINE_BREAKS', not
+                                         is_terminal)
         self.line_breaks = line_breaks
 
-        # Check if ANSI escape characters are enabled (suitable for iteractive terminals),
-        # or should be stripped off (suitable for log files)
+        # Check if ANSI escape characters are enabled (suitable for iteractive
+        # terminals), or should be stripped off (suitable for log files)
         if enable_colors is None:
-            enable_colors = utils.env_flag('PROGRESSBAR_ENABLE_COLORS', is_terminal)
+            enable_colors = utils.env_flag('PROGRESSBAR_ENABLE_COLORS',
+                                           is_terminal)
         self.enable_colors = enable_colors
 
         ProgressBarMixinBase.__init__(self, **kwargs)

--- a/progressbar/utils.py
+++ b/progressbar/utils.py
@@ -58,12 +58,14 @@ def len_color(value):
 
 def env_flag(name, default=None):
     '''
-    Accepts environt variables formatted as y/n, yes/no, 1/0, true/false, on/off, and returns it as a boolean
+    Accepts environt variables formatted as y/n, yes/no, 1/0, true/false,
+    on/off, and returns it as a boolean
 
-    If the environt variable is not defined, or has an unknown value, returns `default`
+    If the environt variable is not defined, or has an unknown value, returns
+    `default`
     '''
     try:
-        return bool(distutils.util.strtobool(os.environ.get(name, "")))
+        return bool(distutils.util.strtobool(os.environ.get(name, '')))
     except ValueError:
         return default
 

--- a/progressbar/widgets.py
+++ b/progressbar/widgets.py
@@ -42,7 +42,7 @@ def create_marker(marker):
 
     if isinstance(marker, six.string_types):
         marker = converters.to_unicode(marker)
-        assert len(marker) == 1, 'Markers are required to be 1 char'
+        assert utils.len_color(marker) == 1, 'Markers are required to be 1 char'
         return _marker
     else:
         return marker

--- a/pytest.ini
+++ b/pytest.ini
@@ -22,3 +22,6 @@ norecursedirs =
 
 filterwarnings =
     ignore::DeprecationWarning
+
+markers =
+    no_freezegun: Disable automatic freezegun wrapping

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,7 +29,8 @@ def small_interval(monkeypatch):
 
 @pytest.fixture(autouse=True)
 def sleep_faster(monkeypatch):
-    with freezegun.freeze_time() as fake_time:
+    freeze_time = freezegun.freeze_time()
+    with freeze_time as fake_time:
         monkeypatch.setattr('time.sleep', fake_time.tick)
         monkeypatch.setattr('timeit.default_timer', time.time)
-        yield
+        yield freeze_time

--- a/tests/test_custom_widgets.py
+++ b/tests/test_custom_widgets.py
@@ -34,7 +34,7 @@ def test_crazy_file_transfer_speed_widget():
     p.finish()
 
 
-def test_dynamic_message_widget():
+def test_variable_widget_widget():
     widgets = [
         ' [', progressbar.Timer(), '] ',
         progressbar.Bar(),
@@ -49,6 +49,7 @@ def test_dynamic_message_widget():
     p = progressbar.ProgressBar(widgets=widgets, max_value=1000,
                                 variables=dict(predefined='predefined'))
     p.start()
+    print('time', time, time.sleep)
     for i in range(0, 200, 5):
         time.sleep(0.1)
         p.update(i + 1, loss=.5, text='spam', error=1)

--- a/tests/test_progressbar.py
+++ b/tests/test_progressbar.py
@@ -1,8 +1,8 @@
+import time
 import pytest
 
 import examples
 import progressbar
-
 import original_examples
 
 
@@ -14,10 +14,17 @@ def test_examples(monkeypatch):
             pass
 
 
-@pytest.mark.filterwarnings('ignore::DeprecationWarning')
-def test_original_examples(monkeypatch):
-    for example in original_examples.examples:
+@pytest.mark.no_freezegun
+@pytest.mark.parametrize('example', original_examples.examples)
+def test_original_examples(example, monkeypatch, sleep_faster):
+    sleep_faster.stop()
+    monkeypatch.setattr(progressbar.ProgressBar,
+                        '_MINIMUM_UPDATE_INTERVAL', 1)
+    monkeypatch.setattr(time, 'sleep', lambda t: None)
+    try:
         example()
+    finally:
+        sleep_faster.start()
 
 
 def test_examples_nullbar(monkeypatch):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,28 @@
+import pytest
+import progressbar
+
+
+@pytest.mark.parametrize('value,expected', [
+    (None, None),
+    ('', None),
+    ('1', True),
+    ('y', True),
+    ('t', True),
+    ('yes', True),
+    ('true', True),
+    ('0', False),
+    ('n', False),
+    ('f', False),
+    ('no', False),
+    ('false', False),
+])
+def test_env_flag(value, expected, monkeypatch):
+    if value is not None:
+        monkeypatch.setenv('TEST_ENV', value)
+    assert progressbar.utils.env_flag('TEST_ENV') == expected
+
+    if value:
+        monkeypatch.setenv('TEST_ENV', value.upper())
+        assert progressbar.utils.env_flag('TEST_ENV') == expected
+
+    monkeypatch.undo()


### PR DESCRIPTION
The problem:
------------

The progressbars are beautiful on an interactive shell.
However, when running from a CI or something else that produces a log file, it is just a big messy blob of garbage.

Depending on how `\r` is handled by the viewer, we get either a very long and noisy line of text, or 3 empty lines between each update.

We also get too many updates for a log file -- This is addressed on #206.

---

The solution:
-------------

It now detects if it is running on an interactive shell via `fd.isatty()`.

This detection is not completely reliable, so it can also be specified via argument or environment variables

If it is not an interactive terminal:
- It writes one update per line, instead of overwrite the existing line
- It removes ANSI color escapes.
