### PR TITLE
Easier to use user-defined placeholders

### DIFF
--- a/examples.py
+++ b/examples.py
@@ -449,13 +449,13 @@ def eta():
 
 @example
 def dynamic_message():
-    # Use progressbar.DynamicMessage to keep track of some parameter(s) during
+    # Use progressbar.Variable to keep track of some parameter(s) during
     # your calculations
     widgets = [
         progressbar.Percentage(),
         progressbar.Bar(),
-        progressbar.DynamicMessage('loss'),
-        progressbar.DynamicMessage('username', width=12, precision=12),
+        progressbar.Variable('loss'),
+        progressbar.Variable('username', width=12, precision=12),
     ]
     with progressbar.ProgressBar(max_value=100, widgets=widgets) as bar:
         min_so_far = 1

--- a/examples.py
+++ b/examples.py
@@ -467,6 +467,38 @@ def dynamic_message():
 
 
 @example
+def user_variables():
+    tasks = {
+        "Download": [
+            "SDK",
+            "IDE",
+            "Dependencies",
+        ],
+        "Build": [
+            "Compile",
+            "Link",
+        ],
+        "Test": [
+            "Unit tests",
+            "Integration tests",
+            "Regression tests",
+        ],
+        "Deploy": [
+            "Send to server",
+            "Restart server",
+        ],
+    }
+    num_subtasks = sum(len(x) for x in tasks.values())
+
+    with progressbar.ProgressBar(prefix="{vars.task} >> {vars.subtask}", vars={"task": '--', "subtask": '--'}, max_value=10*num_subtasks) as bar:
+        for tasks_name, subtasks in tasks.items():
+            for subtask_name in subtasks:
+                for i in range(10):
+                    bar.update(bar.value+1, task=tasks_name, subtask=subtask_name)
+                    time.sleep(0.1)
+
+
+@example
 def format_custom_text():
     format_custom_text = progressbar.FormatCustomText(
         'Spam: %(spam).1f kg, eggs: %(eggs)d',

--- a/progressbar/__init__.py
+++ b/progressbar/__init__.py
@@ -23,6 +23,7 @@ from .widgets import (
     ReverseBar,
     BouncingBar,
     RotatingMarker,
+    Variable,
     DynamicMessage,
     FormatCustomText,
     CurrentTime

--- a/progressbar/bar.py
+++ b/progressbar/bar.py
@@ -183,10 +183,10 @@ class ProgressBar(StdRedirectMixin, ResizableMixin, ProgressBarBase):
             raised when needed
             prefix (str): Prefix the progressbar with the given string
             suffix (str): Prefix the progressbar with the given string
-        vars (dict): User-defined variables that can be used from a label using
-            `format="{vars.my_var}"`.
-            These values can be updated using `bar.update(my_var="newValue")`
-            This can also be used to set initial values for `DynamicMessage`s widgets
+        variables (dict): User-defined variables variables that can be used
+            from a label using `format="{variables.my_var}"`.  These values can
+            be updated using `bar.update(my_var="newValue")` This can also be
+            used to set initial values for `Variable`s widgets
 
     A common way of using it is like:
 
@@ -237,7 +237,8 @@ class ProgressBar(StdRedirectMixin, ResizableMixin, ProgressBarBase):
     def __init__(self, min_value=0, max_value=None, widgets=None,
                  left_justify=True, initial_value=0, poll_interval=None,
                  widget_kwargs=None, custom_len=utils.len_color,
-                 max_error=True, prefix=None, suffix=None, vars={}, **kwargs):
+                 max_error=True, prefix=None, suffix=None, variables=None,
+                 **kwargs):
         '''
         Initializes a progress bar with sane defaults
         '''
@@ -278,13 +279,20 @@ class ProgressBar(StdRedirectMixin, ResizableMixin, ProgressBarBase):
         # low values.
         self.poll_interval = poll_interval
 
-        # A dictionary of names that can be used by DynamicMessage and FormatWidget
-        self.dynamic_messages = utils.AttributeDict()
+        # A dictionary of names that can be used by Variable and FormatWidget
+        self.variables = utils.AttributeDict(variables or {})
         for widget in (self.widgets or []):
-            if isinstance(widget, widgets_module.DynamicMessage):
-                if widget.name not in  self.dynamic_messages:
-                    self.dynamic_messages[widget.name] = None
-        self.dynamic_messages.update(vars)
+            if isinstance(widget, widgets_module.Variable):
+                if widget.name not in self.variables:
+                    self.variables[widget.name] = None
+
+    @property
+    def dynamic_messages(self):  # pragma: no cover
+        return self.variables
+
+    @dynamic_messages.setter
+    def dynamic_messages(self, value):  # pragma: no cover
+        self.variables = value
 
     def init(self):
         '''
@@ -377,9 +385,9 @@ class ProgressBar(StdRedirectMixin, ResizableMixin, ProgressBarBase):
                 - `time_elapsed`: The raw elapsed `datetime.timedelta` object
                 - `percentage`: Percentage as a float or `None` if no max_value
                   is available
-                - `dynamic_messages`: Dictionary of user-defined variables
-                  :py:class:`~progressbar.widgets.DynamicMessage`'s
-                - `vars`: alias for `dynamic_messages`, but shorter name for lazyness.
+                - `dynamic_messages`: Deprecated, use `variables` instead.
+                - `variables`: Dictionary of user-defined variables for the
+                  :py:class:`~progressbar.widgets.Variable`'s
 
         '''
         self._last_update_time = time.time()
@@ -419,10 +427,10 @@ class ProgressBar(StdRedirectMixin, ResizableMixin, ProgressBarBase):
             # Percentage as a float or `None` if no max_value is available
             percentage=self.percentage,
             # Dictionary of user-defined
-            # :py:class:`progressbar.widgets.DynamicMessage`'s
-            dynamic_messages=self.dynamic_messages,
-            # alias for `dynamic_messages`
-            vars=self.dynamic_messages,
+            # :py:class:`progressbar.widgets.Variable`'s
+            variables=self.variables,
+            # Deprecated alias for `variables`
+            dynamic_messages=self.variables,
         )
 
     def default_widgets(self):
@@ -589,8 +597,8 @@ class ProgressBar(StdRedirectMixin, ResizableMixin, ProgressBarBase):
 
         # Save the updated values for dynamic messages
         for key in kwargs:
-            if key in self.dynamic_messages:
-                self.dynamic_messages[key] = kwargs[key]
+            if key in self.variables:
+                self.variables[key] = kwargs[key]
             else:
                 raise TypeError(
                     'update() got an unexpected keyword ' +

--- a/progressbar/utils.py
+++ b/progressbar/utils.py
@@ -200,5 +200,23 @@ class StreamWrapper(object):
         self.flush()
 
 
+class AttributeDict(dict):
+    '''A dict that can be accessed with .attribute'''
+    def __getattr__(self, name):
+        if name in self:
+            return self[name]
+        else:
+            raise AttributeError("No such attribute: " + name)
+
+    def __setattr__(self, name, value):
+        self[name] = value
+
+    def __delattr__(self, name):
+        if name in self:
+            del self[name]
+        else:
+            raise AttributeError("No such attribute: " + name)
+
+
 logger = logging.getLogger(__name__)
 streams = StreamWrapper()

--- a/progressbar/utils.py
+++ b/progressbar/utils.py
@@ -201,7 +201,46 @@ class StreamWrapper(object):
 
 
 class AttributeDict(dict):
-    '''A dict that can be accessed with .attribute'''
+    '''
+    A dict that can be accessed with .attribute
+
+    >>> attrs = AttributeDict(spam=123)
+
+    # Reading
+    >>> attrs['spam']
+    123
+    >>> attrs.spam
+    123
+
+    # Read after update using attribute
+    >>> attrs.spam = 456
+    >>> attrs['spam']
+    456
+    >>> attrs.spam
+    456
+
+    # Read after update using dict access
+    >>> attrs['spam'] = 123
+    >>> attrs['spam']
+    123
+    >>> attrs.spam
+    123
+
+    # Read after update using dict access
+    >>> del attrs.spam
+    >>> attrs['spam']
+    Traceback (most recent call last):
+    ...
+    KeyError: 'spam'
+    >>> attrs.spam
+    Traceback (most recent call last):
+    ...
+    AttributeError: No such attribute: spam
+    >>> del attrs.spam
+    Traceback (most recent call last):
+    ...
+    AttributeError: No such attribute: spam
+    '''
     def __getattr__(self, name):
         if name in self:
             return self[name]

--- a/progressbar/widgets.py
+++ b/progressbar/widgets.py
@@ -728,25 +728,25 @@ class FormatCustomText(FormatWidgetMixin, WidthWidgetMixin):
             self, progress, self.mapping, self.format)
 
 
-class DynamicMessage(FormatWidgetMixin, WidgetBase):
+class Variable(FormatWidgetMixin, WidgetBase):
     '''Displays a custom variable.'''
 
     def __init__(self, name, format='{name}: {formatted_value}',
                  width=6, precision=3):
-        '''Creates a DynamicMessage associated with the given name.'''
+        '''Creates a Variable associated with the given name.'''
         self.format = format
         self.width = width
         self.precision = precision
         if not isinstance(name, str):
-            raise TypeError('DynamicMessage(): argument must be a string')
+            raise TypeError('Variable(): argument must be a string')
         if len(name.split()) > 1:
             raise ValueError(
-                'DynamicMessage(): argument must be single word')
+                'Variable(): argument must be single word')
 
         self.name = name
 
     def __call__(self, progress, data):
-        value = data['dynamic_messages'][self.name]
+        value = data['variables'][self.name]
         context = data.copy()
         context['value'] = value
         context['name'] = self.name
@@ -764,6 +764,11 @@ class DynamicMessage(FormatWidgetMixin, WidgetBase):
                 context['formatted_value'] = '-' * self.width
 
         return self.format.format(**context)
+
+
+class DynamicMessage(Variable):
+    '''Kept for backwards compatibility, please use `Variable` instead.'''
+    pass
 
 
 class CurrentTime(FormatWidgetMixin, TimeSensitiveWidgetBase):

--- a/tests/test_custom_widgets.py
+++ b/tests/test_custom_widgets.py
@@ -39,12 +39,15 @@ def test_dynamic_message_widget():
         ' [', progressbar.Timer(), '] ',
         progressbar.Bar(),
         ' (', progressbar.ETA(), ') ',
-        progressbar.DynamicMessage('loss'),
-        progressbar.DynamicMessage('text'),
-        progressbar.DynamicMessage('error', precision=None),
+        progressbar.Variable('loss'),
+        progressbar.Variable('text'),
+        progressbar.Variable('error', precision=None),
+        progressbar.Variable('missing'),
+        progressbar.Variable('predefined'),
     ]
 
-    p = progressbar.ProgressBar(widgets=widgets, max_value=1000)
+    p = progressbar.ProgressBar(widgets=widgets, max_value=1000,
+                                variables=dict(predefined='predefined'))
     p.start()
     for i in range(0, 200, 5):
         time.sleep(0.1)

--- a/tests/test_failure.py
+++ b/tests/test_failure.py
@@ -107,11 +107,11 @@ def test_unexpected_update_keyword_arg():
             p.update(i, foo=10)
 
 
-def test_dynamic_message_not_str():
+def test_variable_not_str():
     with pytest.raises(TypeError):
-        progressbar.DynamicMessage(1)
+        progressbar.Variable(1)
 
 
-def test_dynamic_message_too_many_strs():
+def test_variable_too_many_strs():
     with pytest.raises(ValueError):
-        progressbar.DynamicMessage('too long')
+        progressbar.Variable('too long')


### PR DESCRIPTION
I often want to display a task name before the progress bar.

While this is possible with DynamicMessage and FormatCustomText, I find that it could be better: 

- I want placeholders to be very easy to setup: Just adding `prefix="{placeholders.myPlaceholder}` instead of seting up custom widgets
- I want them to be easy to update, with `bar.update(myPlaceholder=newValue)`

This adds a new `placeholders={"name": "value"}` parameter to the constructor, which must be used to set initial values to all placeholders. 

### Format syntax 

Everything is stored into the `placeholders` object: 
We can use a `format="{placeholders.myPlaceholder}"` to display them in a FormatLabel.

Another option would be to make the placeholders available at the top level: `format="{myPlaceholder}"`, however I wanted to avoid name conflicts with progressbar's existing variables. 

### Implementation details:

The placeholders share the storage with dynamic messages.

I had to created a helper class `AttributeDict`, which allows using `format="{placeholders.myPlaceholder}"`, because `format="{placeholders['myPlaceholder']}"` doesn't seem to work (Python bug?)

I have renamed the attribute `bar.dynamic_messages` to `bar.placeholders`. Thoughts on that?