### PR TITLE
Prevent updating too often

### DIFF
--- a/examples.py
+++ b/examples.py
@@ -455,15 +455,17 @@ def dynamic_message():
         progressbar.Percentage(),
         progressbar.Bar(),
         progressbar.DynamicMessage('loss'),
+        ", ",
         progressbar.DynamicMessage('username', width=12, precision=12),
     ]
     with progressbar.ProgressBar(max_value=100, widgets=widgets) as bar:
         min_so_far = 1
         for i in range(100):
+            time.sleep(0.01)
             val = random.random()
             if val < min_so_far:
                 min_so_far = val
-            bar.update(i, loss=min_so_far, username='Some user %02d' % i)
+            bar.update(i, loss=min_so_far, username='Some user')
 
 
 @example


### PR DESCRIPTION
On #175 and #204, we discussed about rate-limiting updates to avoid flooding log files.

This PR addressed this by adding `min_pool_interval` parameter, which works exactly like the existing `_MINIMUM_UPDATE_INTERVAL`
(It can also be specified by the environment variable `PROGRESSBAR_MINIMUM_UPDATE_INTERVAL`)

I also refactored all the checks into `_needs_update`, and added a bypass in case a dynamic_message changes.