### PR TITLE
Avoid flickering

### DIFF
--- a/examples.py
+++ b/examples.py
@@ -32,6 +32,19 @@ def example(fn):
 
 
 @example
+def fast_example():
+    ''' Updates bar really quickly to cause flickering '''
+    with progressbar.ProgressBar(max_value=1, widgets=[progressbar.Bar()]) as bar:
+        start = time.time()
+        while True:
+            elapsed = time.time() - start
+            if elapsed > 1:
+                break
+            else:
+                bar.update(elapsed, force=True)
+
+
+@example
 def shortcut_example():
     for i in progressbar.progressbar(range(10)):
         time.sleep(0.1)

--- a/progressbar/bar.py
+++ b/progressbar/bar.py
@@ -180,9 +180,10 @@ class StdRedirectMixin(DefaultFdMixin):
         DefaultFdMixin.start(self, *args, **kwargs)
 
     def update(self, value=None):
-        if not self.line_breaks:
-            self.fd.write('\r' + ' ' * self.term_width + '\r')
-        utils.streams.flush()
+        if utils.streams.needs_flush():
+            if not self.line_breaks:
+                self.fd.write('\r' + ' ' * self.term_width + '\r')
+            utils.streams.flush()
         DefaultFdMixin.update(self, value=value)
 
     def finish(self, end='\n'):

--- a/progressbar/utils.py
+++ b/progressbar/utils.py
@@ -135,6 +135,9 @@ class WrappingIO:
     def flush(self):
         self.buffer.flush()
 
+    def _needs_flush(self):
+        return bool(self.buffer.getvalue())
+
     def _flush(self):
         value = self.buffer.getvalue()
         if value:
@@ -248,6 +251,15 @@ class StreamWrapper(object):
         else:
             sys.stderr = self.original_stderr
             self.wrapped_stderr = 0
+
+    def needs_flush(self):
+        if self.wrapped_stdout:
+            if self.stdout._needs_flush():
+                return True
+        if self.wrapped_stderr:
+            if self.stderr._needs_flush():
+              return True
+        return False
 
     def flush(self):
         if self.wrapped_stdout:  # pragma: no branch


### PR DESCRIPTION
StdRedirectMixin makes the bar erase itself before writing the new update.

This works fine and is invisible most of the time.
But only most of the time -- If the refreshes are very fast, flickering becomes visible
    
This PR first checks if there is something buffered to be written in stdout/stderr, and doesn't erase the current line otherwise