### PR TITLE
Remove empty __pycache__ folders before sdist

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,7 @@ clean-pyc:
 	find . -name '*.pyc' -exec rm -f {} +
 	find . -name '*.pyo' -exec rm -f {} +
 	find . -name '*~' -exec rm -f {} +
+	find . -name __pycache__ -type d -delete
 
 lint:
 	flake8 progressbar tests


### PR DESCRIPTION
Noticed in NixOS/nixpkgs#91493 (comment) that the sdist wasn't cleaned before being uploaded.

Likely, the makefile wasn't used to create the sdist, as the pyc's and pyo's should have been removed.

```
[nix-shell:/home/jon/.cache/nixpkgs-review/pr-91493-2]$ tar xf /nix/store/ik4d0wbv8w8h1mbx6rb38qjx6w4h8jmj-progressbar2-3.51.3.tar.gz

[nix-shell:/home/jon/.cache/nixpkgs-review/pr-91493-2]$ cd progressbar2-3.51.3/
CHANGES.rst       examples.py  Makefile     PKG-INFO     progressbar2.egg-info  README.rst  setup.py
CONTRIBUTING.rst  LICENSE      MANIFEST.in  progressbar  pytest.ini             setup.cfg   tests

[nix-shell:/home/jon/.cache/nixpkgs-review/pr-91493-2/progressbar2-3.51.3]$ ls tests/__pycache__/
conftest.cpython-27-PYTEST.pyc                      test_multibar.cpython-27-PYTEST.pyc
conftest.cpython-37-pytest-5.3.1.pyc                test_multibar.cpython-37-pytest-5.3.1.pyc
conftest.cpython-38-pytest-5.3.5.pyc                test_multibar.cpython-38-pytest-5.3.5.pyc
conftest.cpython-38-pytest-5.4.1.pyc                test_multibar.cpython-38-pytest-5.4.1.pyc
original_examples.cpython-27-PYTEST.pyc             test_progressbar.cpython-27-PYTEST.pyc
original_examples.cpython-37-pytest-5.3.1.pyc       test_progressbar.cpython-37-pytest-5.3.1.pyc
original_examples.cpython-38-pytest-5.3.5.pyc       test_progressbar.cpython-38-pytest-5.3.5.pyc
original_examples.cpython-38-pytest-5.4.1.pyc       test_progressbar.cpython-38-pytest-5.4.1.pyc
test_custom_widgets.cpython-27-PYTEST.pyc           test_samples.cpython-27-PYTEST.pyc
test_custom_widgets.cpython-37-pytest-5.3.1.pyc     test_samples.cpython-37-pytest-5.3.1.pyc
test_custom_widgets.cpython-38-pytest-5.3.5.pyc     test_samples.cpython-38-pytest-5.3.5.pyc
test_custom_widgets.cpython-38-pytest-5.4.1.pyc     test_samples.cpython-38-pytest-5.4.1.pyc
test_data.cpython-27-PYTEST.pyc                     test_speed.cpython-27-PYTEST.pyc
test_data.cpython-37-pytest-5.3.1.pyc               test_speed.cpython-37-pytest-5.3.1.pyc
test_data.cpython-38-pytest-5.3.5.pyc               test_speed.cpython-38-pytest-5.3.5.pyc
test_data.cpython-38-pytest-5.4.1.pyc               test_speed.cpython-38-pytest-5.4.1.pyc
test_data_transfer_bar.cpython-27-PYTEST.pyc        test_stream.cpython-27-PYTEST.pyc
test_data_transfer_bar.cpython-37-pytest-5.3.1.pyc  test_stream.cpython-37-pytest-5.3.1.pyc
test_data_transfer_bar.cpython-38-pytest-5.3.5.pyc  test_stream.cpython-38-pytest-5.3.5.pyc
test_data_transfer_bar.cpython-38-pytest-5.4.1.pyc  test_stream.cpython-38-pytest-5.4.1.pyc
test_empty.cpython-27-PYTEST.pyc                    test_terminal.cpython-27-PYTEST.pyc
test_empty.cpython-37-pytest-5.3.1.pyc              test_terminal.cpython-37-pytest-5.3.1.pyc
test_empty.cpython-38-pytest-5.3.5.pyc              test_terminal.cpython-38-pytest-5.3.5.pyc
test_empty.cpython-38-pytest-5.4.1.pyc              test_terminal.cpython-38-pytest-5.4.1.pyc
test_end.cpython-27-PYTEST.pyc                      test_timed.cpython-27-PYTEST.pyc
test_end.cpython-37-pytest-5.3.1.pyc                test_timed.cpython-37-pytest-5.3.1.pyc
test_end.cpython-38-pytest-5.3.5.pyc                test_timed.cpython-38-pytest-5.3.5.pyc
test_end.cpython-38-pytest-5.4.1.pyc                test_timed.cpython-38-pytest-5.4.1.pyc
test_failure.cpython-27-PYTEST.pyc                  test_timer.cpython-27-PYTEST.pyc
test_failure.cpython-37-pytest-5.3.1.pyc            test_timer.cpython-37-pytest-5.3.1.pyc
test_failure.cpython-38-pytest-5.3.5.pyc            test_timer.cpython-38-pytest-5.3.5.pyc
test_failure.cpython-38-pytest-5.4.1.pyc            test_timer.cpython-38-pytest-5.4.1.pyc
test_flush.cpython-27-PYTEST.pyc                    test_unicode.cpython-27-PYTEST.pyc
test_flush.cpython-37-pytest-5.3.1.pyc              test_unicode.cpython-37-pytest-5.3.1.pyc
test_flush.cpython-38-pytest-5.3.5.pyc              test_unicode.cpython-38-pytest-5.3.5.pyc
test_flush.cpython-38-pytest-5.4.1.pyc              test_unicode.cpython-38-pytest-5.4.1.pyc
test_iterators.cpython-27-PYTEST.pyc                test_unknown_length.cpython-27-PYTEST.pyc
test_iterators.cpython-37-pytest-5.3.1.pyc          test_unknown_length.cpython-37-pytest-5.3.1.pyc
test_iterators.cpython-38-pytest-5.3.5.pyc          test_unknown_length.cpython-38-pytest-5.3.5.pyc
test_iterators.cpython-38-pytest-5.4.1.pyc          test_unknown_length.cpython-38-pytest-5.4.1.pyc
test_large_values.cpython-27-PYTEST.pyc             test_utils.cpython-27-PYTEST.pyc
test_large_values.cpython-37-pytest-5.3.1.pyc       test_utils.cpython-37-pytest-5.3.1.pyc
test_large_values.cpython-38-pytest-5.3.5.pyc       test_utils.cpython-38-pytest-5.3.5.pyc
test_large_values.cpython-38-pytest-5.4.1.pyc       test_utils.cpython-38-pytest-5.4.1.pyc
test_misc.cpython-27-PYTEST.pyc                     test_widgets.cpython-27-PYTEST.pyc
test_misc.cpython-37-pytest-5.3.1.pyc               test_widgets.cpython-37-pytest-5.3.1.pyc
test_misc.cpython-38-pytest-5.3.5.pyc               test_widgets.cpython-38-pytest-5.3.5.pyc
test_misc.cpython-38-pytest-5.4.1.pyc               test_widgets.cpython-38-pytest-5.4.1.pyc
test_monitor_progress.cpython-27-PYTEST.pyc         test_with.cpython-27-PYTEST.pyc
test_monitor_progress.cpython-37-pytest-5.3.1.pyc   test_with.cpython-37-pytest-5.3.1.pyc
test_monitor_progress.cpython-38-pytest-5.3.5.pyc   test_with.cpython-38-pytest-5.3.5.pyc
test_monitor_progress.cpython-38-pytest-5.4.1.pyc   test_with.cpython-38-pytest-5.4.1.pyc
```