### PR TITLE
Delegate unknown attrs to target in WrappingIO

### DIFF
--- a/progressbar/utils.py
+++ b/progressbar/utils.py
@@ -199,8 +199,8 @@ class WrappingIO:
         self.listeners = listeners or set()
         self.needs_clear = False
 
-    def isatty(self):  # pragma: no cover
-        return self.target.isatty()
+    def __getattr__(self, name):  # pragma: no cover
+        return getattr(self.target, name)
 
     def write(self, value: str) -> None:
         if self.capturing:


### PR DESCRIPTION
Same idea as fbb2f4d18703f387349e77c126214d8eb9bd89c1 but more generic.
Only the flushing should be wrapped, everything else should behave like
it would on the target.

The issue arises while trying to access attributes like `encoding` or
`fileno`.