### PR TITLE
Fixed excluding docs from install

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,7 +103,7 @@ dependencies = ['python-utils >= 3.8.1']
 version = { attr = 'progressbar.__about__.__version__' }
 
 [tool.setuptools.packages.find]
-exclude = ['docs', 'tests']
+exclude = ['docs*', 'tests*']
 
 [tool.setuptools]
 include-package-data = true


### PR DESCRIPTION
Fix the exclusion rules to use wildcards, as that is necessary to recursive exclude a directory.  Otherwise, `docs/_theme` is still included.