### PR TITLE
Handle OSError exception from format_time() in ETA.__call__()

### DIFF
--- a/progressbar/widgets.py
+++ b/progressbar/widgets.py
@@ -547,7 +547,7 @@ class ETA(Timer):
 
         data['eta'] = None
         if data['eta_seconds']:
-            with contextlib.suppress(ValueError, OverflowError):
+            with contextlib.suppress(ValueError, OverflowError, OSError):
                 data['eta'] = utils.format_time(data['eta_seconds'])
 
         if data['value'] == progress.min_value:
@@ -560,7 +560,7 @@ class ETA(Timer):
             fmt = self.format_NA
         else:
             fmt = self.format_zero
-
+:
         return Timer.__call__(self, progress, data, format=fmt)
 
 


### PR DESCRIPTION
In Windows CPython, format_time() can throw "OSError: [Errno 22] Invalid argument" when passed a very large date. Ignore this in ETA.__call__() with contextlib.suppress().  Fixes #297.